### PR TITLE
fix_logs v!

### DIFF
--- a/logback-spring.xml
+++ b/logback-spring.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="true">
     <property name="LOGS" value="logs/jmsm.log"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
                 %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable
@@ -10,6 +13,7 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+
         <file>${LOGS}</file>
         <append>true</append>
         <immediateFlush>true</immediateFlush>
@@ -18,11 +22,23 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <logger name="org.springframework.web" level="trace">
         <appender-ref ref="CONSOLE"/>
-    </root>
+    </logger>
 
-    <logger name="jm" level="trace" additivity="false">
+    <logger name="org.springframework" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="jm" level="ERROR" additivity="false">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
     </logger>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -12,12 +12,7 @@
     <artifactId>webapp</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <logback.version>1.2.3</logback.version>
-        <slf4j.version>1.7.28</slf4j.version>
-    </properties>
-
-    <dependencies>
+      <dependencies>
 
         <dependency>
             <groupId>groupId</groupId>
@@ -31,22 +26,7 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-        </dependency>
+
 
 
     </dependencies>

--- a/webapp/src/main/java/jm/config/inititalizer/TestDataInitializer.java
+++ b/webapp/src/main/java/jm/config/inititalizer/TestDataInitializer.java
@@ -44,7 +44,7 @@ public class TestDataInitializer {
             roleOwner.setRole(ownerRole);
             roleDAO.persist(roleOwner);
         }
-        if (roleDAO.getRoleByRolename(userRole) == null){
+        if (roleDAO.getRoleByRolename(userRole) == null) {
             Role roleUser = new Role();
             roleUser.setRole(userRole);
             roleDAO.persist(roleUser);
@@ -55,6 +55,8 @@ public class TestDataInitializer {
         Role role = roleDAO.getRoleByRolename(userRole);
         Set<Role> roleSet = new HashSet<>();
         roleSet.add(role);
+
+        logger.error("Exception to FILE: ", new NoSuchFieldError());
 
         for (int i = 0; i < 15; i++) {
             usersArray[i] = new User("name-" + i, "last-name-" + i, "login-" + i, "mymail" + i + "@testmail.com", "pass-" + i);

--- a/webapp/src/main/resources/application.properties
+++ b/webapp/src/main/resources/application.properties
@@ -1,11 +1,16 @@
+spring.profiles.active=default
+
 server.port=6666
 
 spring.datasource.url=jdbc:mysql://localhost:3306/test_db?characterEncoding=UTF-8&useUnicode=true&useSSL=false&serverTimezone=GMT
 spring.datasource.username=root
 spring.datasource.password=123
 spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+
 spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
 
 spring.thymeleaf.cache=false
+
+logging.config=logback-spring.xml
+
+


### PR DESCRIPTION
Важные моменты:

1.  application.properties изменен. 
**spring.profiles.active=default** - для ясности, чтобы не было warnings, что не нашли дефолт контекст.
**logging.config=logback-spring.xml** - откуда, собственно, берем конфигурацию логирования.
2. **spring.jpa.show-sql=true** - **обязательно** убрать!!! Выводит неинформативные запросы SQL(HQL).

3. **logback-spring.xml** - переехал в корень проекта из templates. Так его ищет Spring Boot.

По настройкам:

> `<logger name="org.springframework.web" level="trace">
        <appender-ref ref="CONSOLE"/>
</logger>`

отвечает за вывод маппинга конроллеров. Уровня INFO, как было ранее, не хватало. Нужен TRACE. В этом было дело. Вывод только на консоль. если надо, добавить:
`<appender-ref ref="FILE"/>` для вывода в файл.

`<logger name="org.springframework" level="INFO" additivity="false">
        <appender-ref ref="CONSOLE"/>
    </logger>` - логи Spring Framework, кроме пакета web.

`<logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
        <appender-ref ref="CONSOLE"/>
    </logger>` для вывода информативного запроса HQL.

` <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" additivity="false">
        <appender-ref ref="CONSOLE"/>
    </logger>` для вывода параметров, передаваемых в тело запроса HQL.

`<logger name="jm" level="ERROR" additivity="false">
        <appender-ref ref="CONSOLE"/>
        <appender-ref ref="FILE"/>
    </logger>` собственно, логгер пакета jm. Пишется и в консоль, и в файл. Тут тестировал вывод Exceptions. `logger.error("Exception to FILE: ", new NoSuchFieldError());` примерно так. Работает.


