### PR TITLE
в предыдущем случае получалась полная дата+время, хотя по комментам д…

### DIFF
--- a/webapp/src/main/resources/static/js/workspace-page/components/footer/messages.js
+++ b/webapp/src/main/resources/static/js/workspace-page/components/footer/messages.js
@@ -209,7 +209,7 @@ window.updateMessages = function updateMessages() {
                                                                         ${time}
                                                                     </span>
                                                                     <span class="c-timestamp__label">
-                                                                        ${message.dateCreate}
+                                                                        ${date}
                                                                     </span>                                                                     
                                                                 </a>
                                                             </div>


### PR DESCRIPTION
…олжна быть только дата, время тут отдельно добавленно перед! Можно либо удалить время перед, что уменьшит количество переменных, но тогда время будет стоять за датой!