### PR TITLE
Fix: Set header information when swithing between channels and direct…

### DIFF
--- a/webapp/src/main/resources/static/js/workspace-page/components/navbar/NavHeader.js
+++ b/webapp/src/main/resources/static/js/workspace-page/components/navbar/NavHeader.js
@@ -1,0 +1,54 @@
+export class NavHeader {
+
+    constructor() {
+        this.header = $('.p-classic_nav__model__title');
+    }
+
+    setChannelTitle(channel_icon, channel_name) {
+        this.header
+            .find('.p-classic_nav__model__title__name__button')
+            .replaceWith(`
+                <div class="p-classic_nav__model__title__name__button">
+                    <i class="p-classic_nav__model__title__name__hash_icon">${channel_icon}</i>
+                    <span class="p-classic_nav__model__title__info__name">${channel_name}</span> 
+                </div>
+            `);
+
+        return this;
+    }
+
+    setInfo() {
+        this.header
+            .find('.p-classic_nav__model__title__info')
+            .replaceWith(`
+                <div class="p-classic_nav__model__title__info">
+                    <button class="p-classic_nav__model__title__info__star">
+                        <i class="p-classic_nav__model__title__info__star__icon">☆</i>
+                    </button>
+                    <span class="p-classic_nav__model__title__info__sep">|</span>
+                        <button class="p-classic_nav__model__title__info__members">
+                        <i class="p-classic_nav__model__title__info__members__icon">👨</i>
+                    &nbsp;
+                    -
+                    <!--                                                               Members Count-->
+                    </button>
+                    <span class="p-classic_nav__model__title__info__sep">|</span>
+                        <button class="p-classic_nav__model__title__info__pins">
+                        <i class="p-classic_nav__model__title__info__pins__icon">📍</i>
+                    &nbsp;
+                    -
+                    <!--                                                                  Pins Count-->
+                    </button>
+                    <span class="p-classic_nav__model__title__info__sep">|</span>
+                    <div class="p-classic_nav__model__title__info__item">
+                        <div id="topic_string_block" class="p-classic_nav__model__title__info__topic__text">
+                            <span id="topic_string" class="p-classic_nav__model__title__info__topic__content">Enter channel topic here.</span>
+                            <button id="topic_button" style="display: none;" class="p-classic_nav__model__title__info__topic__edit">
+                                Edit
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            `);
+    }
+}

--- a/webapp/src/main/resources/static/js/workspace-page/workspace-page.js
+++ b/webapp/src/main/resources/static/js/workspace-page/workspace-page.js
@@ -8,7 +8,9 @@ import {
 import {getAllUsersInThisChannel} from "../ajax/userRestController.js";
 import {updateAllMessages} from "./components/footer/messages.js";
 import {refreshMemberList} from "../member-list/member-list.js";
+import {NavHeader} from "./components/navbar/NavHeader.js";
 
+const wks_header = new NavHeader();
 const channel_service = new ChannelRestPaginationService();
 const bot_service = new BotRestPaginationService();
 const workspace_service = new WorkspaceRestPaginationService();
@@ -22,6 +24,7 @@ user_service.getLoggedUser().then(loggedUser => {
     loggedUserId = loggedUser.id;
     console.log(loggedUserId);
 });
+
 
 const showDefaultChannel = () => {
     let workspace_id = workspace_service.getChoosedWorkspace();
@@ -68,12 +71,12 @@ $(document).ready(() => {
 });
 
 $(".p-channel_sidebar__channels__list").on("click", "button.p-channel_sidebar__name_button", function () {
+    wks_header.setChannelTitle($(this).find('i').text(), $(this).find('span').text()).setInfo();
+
     const channel_id = parseInt($(this).val());
     pressChannelButton(channel_id);
 
     sessionStorage.setItem("channelName", channel_id);
-    var channel_name = document.getElementById("channel_name_" + channel_id).textContent;
-    $(".p-classic_nav__model__title__info__name").html("").text(channel_name);
     sessionStorage.setItem('conversation_id', '0'); // direct msgs
 
     refreshMemberList();


### PR DESCRIPTION
This fixes the header title issue. When selecting a direct message chat and after switching back to a channel, the title and info were not being set with channel information. 



