### PR TITLE
Изменена версия JDK с 8 на 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.11</maven.compiler.source>
+        <maven.compiler.target>1.11</maven.compiler.target>
         <mysql.version>8.0.16</mysql.version>
         <tomcat.version>9.0.22</tomcat.version>
         <jquery.version>3.4.1</jquery.version>


### PR DESCRIPTION
Изменена версия JDK с 8 на 11. Работа корректна на OpenJDK ver. 11.0.2 и JDK ver.11.0.7 by Oracle.